### PR TITLE
Add more options to xcodebuild and altool

### DIFF
--- a/Sources/XCTools/Altool/Altool.swift
+++ b/Sources/XCTools/Altool/Altool.swift
@@ -1,9 +1,9 @@
 import Sh
 
 public struct Altool {
-  let credential: AltoolCredential
+    let credential: any AltoolCredential
 
-  public init(credential: AltoolCredential) {
-    self.credential = credential
-  }
+    public init(credential: some AltoolCredential) {
+        self.credential = credential
+    }
 }

--- a/Sources/XCTools/Altool/Altool.uploadApp.swift
+++ b/Sources/XCTools/Altool/Altool.uploadApp.swift
@@ -1,18 +1,19 @@
-import Sh
 import Foundation
+import Sh
 
 extension Altool {
+    public func uploadApp(
+        _ sink: Sink = .terminal,
+        file: String,
+        platform: Platform,
+        transport: [Transport]? = nil
+    ) async throws {
+        var buffer = "xcrun altool --upload-app -f \(file) -t \(platform) \(credential.serialized)"
 
-  public func uploadApp(_ sink: Sink = .terminal, file: String, platform: Platform, transport: [Transport]? = nil) async throws {
+        if let transport {
+            buffer.append(transport.serialized)
+        }
 
-    var buffer = "xcrun altool \(credential.serialized) --upload-app -f \(file) -t \(platform)"
-
-    if let transport = transport {
-      buffer.append(transport.serialized)
+        try await sh(sink, buffer, environment: credential.environment)
     }
-
-    try await sh(sink,
-           buffer,
-           environment: self.credential.environment)
-  }
 }

--- a/Sources/XCTools/Altool/Altool.validateApp.swift
+++ b/Sources/XCTools/Altool/Altool.validateApp.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Sh
+
+extension Altool {
+    public func validateApp(
+        _ sink: Sink = .terminal,
+        file: String,
+        platform: Platform
+    ) async throws {
+        let command = "xcrun altool --validate-app -f \(file) -t \(platform) \(credential.serialized)"
+
+        try await sh(sink, command, environment: credential.environment)
+    }
+}

--- a/Sources/XCTools/Xcodebuild/Xcodebuild.exportArchive.swift
+++ b/Sources/XCTools/Xcodebuild/Xcodebuild.exportArchive.swift
@@ -2,21 +2,38 @@ import Sh
 
 extension Xcodebuild {
 
-  public func exportArchive(_ sink: Sink = .terminal, archivePath: String, exportPath: String? = nil, exportOptionsPlistPath: String) async throws {
-    var buffer = "xcrun xcodebuild -exportArchive -archivePath \(archivePath) -exportOptionsPlist \(exportOptionsPlistPath)"
+    public func exportArchive(
+        _ sink: Sink = .terminal,
+        archivePath: String,
+        exportPath: String? = nil,
+        exportOptionsPlistPath: String
+    ) async throws {
+        var buffer = "xcodebuild -exportArchive -archivePath \(archivePath) -exportOptionsPlist \(exportOptionsPlistPath)"
 
-    if let exportPath = exportPath {
-      buffer.append(" -exportPath \(exportPath)")
+        if let exportPath = exportPath {
+            buffer.append(" -exportPath \(exportPath)")
+        }
+
+        if allowProvisioningUpdates {
+            buffer.append(" -allowProvisioningUpdates")
+        }
+
+        if allowProvisioningDeviceRegistration {
+            buffer.append(" -allowProvisioningDeviceRegistration")
+        }
+
+        if let authenticationKeyPath = authenticationKeyPath {
+            buffer.append(" -authenticationKeyPath \(authenticationKeyPath)")
+        }
+
+        if let authenticationKeyID = authenticationKeyID {
+            buffer.append(" -authenticationKeyID \(authenticationKeyID)")
+        }
+
+        if let authenticationKeyIssuerID = authenticationKeyIssuerID {
+            buffer.append(" -authenticationKeyIssuerID \(authenticationKeyIssuerID)")
+        }
+
+        try await sh(sink, buffer)
     }
-
-    if allowProvisioningUpdates {
-      buffer.append(" -allowProvisioningUpdates")
-    }
-
-    if allowProvisioningDeviceRegistration {
-      buffer.append(" -allowProvisioningDeviceRegistration")
-    }
-
-    try await sh(sink, buffer)
-  }
 }

--- a/Sources/XCTools/Xcodebuild/Xcodebuild.swift
+++ b/Sources/XCTools/Xcodebuild/Xcodebuild.swift
@@ -82,7 +82,7 @@ public struct Xcodebuild {
     }
 
     func serializedCommand(action: String) -> String {
-        var buffer = "xcrun xcodebuild"
+        var buffer = "xcodebuild"
 
         if let project = project {
             buffer.append(" -project \(project)")

--- a/Sources/XCTools/Xcodebuild/Xcodebuild.swift
+++ b/Sources/XCTools/Xcodebuild/Xcodebuild.swift
@@ -11,6 +11,8 @@ public struct Xcodebuild {
     let arch: [String]?
     let sdk: String?
 
+    let quiet: Bool
+    let verbose: Bool
     let showBuildTimingSummary: Bool
     let enableThreadSanitizer: Bool?
     let enableUndefinedBehaviorSanitizer: Bool?
@@ -35,6 +37,8 @@ public struct Xcodebuild {
         configuraton: String? = nil,
         arch: [String]? = nil,
         sdk: String? = nil,
+        quiet: Bool = false,
+        verbose: Bool = false,
         showBuildTimingSummary: Bool = false,
         enableThreadSanitizer: Bool? = nil,
         enableUndefinedBehaviorSanitizer: Bool? = nil,
@@ -58,6 +62,8 @@ public struct Xcodebuild {
         self.configuraton = configuraton
         self.arch = arch
         self.sdk = sdk
+        self.quiet = quiet
+        self.verbose = verbose
         self.showBuildTimingSummary = showBuildTimingSummary
         self.enableThreadSanitizer = enableThreadSanitizer
         self.enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer
@@ -102,6 +108,14 @@ public struct Xcodebuild {
 
         if let sdk = sdk {
             buffer.append(" -sdk \(sdk)")
+        }
+
+        if quiet {
+            buffer.append(" -quiet")
+        }
+
+        if verbose {
+            buffer.append(" -verbose")
         }
 
         if showBuildTimingSummary {

--- a/Sources/XCTools/Xcodebuild/Xcodebuild.swift
+++ b/Sources/XCTools/Xcodebuild/Xcodebuild.swift
@@ -3,156 +3,172 @@ import Foundation
 
 public struct Xcodebuild {
 
-  let project: String?
-  let workspace: String?
-  let scheme: String?
-  let destination: Destination?
-  let configuraton: String?
-  let arch: [String]?
-  let sdk: String?
+    let project: String?
+    let workspace: String?
+    let scheme: String?
+    let destination: Destination?
+    let configuraton: String?
+    let arch: [String]?
+    let sdk: String?
 
-  let showBuildTimingSummary: Bool
-  let enableThreadSanitizer: Bool?
-  let enableUndefinedBehaviorSanitizer: Bool?
-  let enableCodeCoverage: Bool?
-  let testLanguage: String?
-  let testRegion: String?
-  let derivedDataPath: String?
-  let resultBundlePath: String?
-  let allowProvisioningUpdates: Bool
-  let allowProvisioningDeviceRegistration: Bool
-  let authenticationKeyPath: String?
-  let authenticationKeyID: String?
-  let authenticationKeyIssuerID: String?
+    let showBuildTimingSummary: Bool
+    let enableThreadSanitizer: Bool?
+    let enableUndefinedBehaviorSanitizer: Bool?
+    let enableCodeCoverage: Bool?
+    let testLanguage: String?
+    let testRegion: String?
+    let derivedDataPath: String?
+    let resultBundlePath: String?
+    let allowProvisioningUpdates: Bool
+    let allowProvisioningDeviceRegistration: Bool
+    let authenticationKeyPath: String?
+    let authenticationKeyID: String?
+    let authenticationKeyIssuerID: String?
+    let skipPackagePluginValidation: Bool
+    let skipMacroValidation: Bool
 
-  public init(project: String? = nil,
-              workspace: String? = nil,
-              scheme: String? = nil,
-              destination: Destination? = nil,
-              configuraton: String? = nil,
-              arch: [String]? = nil,
-              sdk: String? = nil,
-              showBuildTimingSummary: Bool = false,
-              enableThreadSanitizer: Bool? = nil,
-              enableUndefinedBehaviorSanitizer: Bool? = nil,
-              enableCodeCoverage: Bool? = nil,
-              testLanguage: String? = nil,
-              testRegion: String? = nil,
-              derivedDataPath: String? = nil,
-              resultBundlePath: String? = nil,
-              allowProvisioningUpdates: Bool = false,
-              allowProvisioningDeviceRegistration: Bool = false,
-              authenticationKeyPath: String? = nil,
-              authenticationKeyID: String? = nil,
-              authenticationKeyIssuerID: String? = nil) {
-    self.project = project
-    self.workspace = workspace
-    self.scheme = scheme
-    self.destination = destination
-    self.configuraton = configuraton
-    self.arch = arch
-    self.sdk = sdk
-    self.showBuildTimingSummary = showBuildTimingSummary
-    self.enableThreadSanitizer = enableThreadSanitizer
-    self.enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer
-    self.enableCodeCoverage = enableCodeCoverage
-    self.testLanguage = testLanguage
-    self.testRegion = testRegion
-    self.derivedDataPath = derivedDataPath
-    self.resultBundlePath = resultBundlePath
-    self.allowProvisioningUpdates = allowProvisioningUpdates
-    self.allowProvisioningDeviceRegistration = allowProvisioningDeviceRegistration
-    self.authenticationKeyPath = authenticationKeyPath
-    self.authenticationKeyID = authenticationKeyID
-    self.authenticationKeyIssuerID = authenticationKeyIssuerID
-  }
-
-  func serializedCommand(action: String) -> String {
-    var buffer = "xcrun xcodebuild"
-
-    if let project = project {
-      buffer.append(" -project \(project)")
+    public init(
+        project: String? = nil,
+        workspace: String? = nil,
+        scheme: String? = nil,
+        destination: Destination? = nil,
+        configuraton: String? = nil,
+        arch: [String]? = nil,
+        sdk: String? = nil,
+        showBuildTimingSummary: Bool = false,
+        enableThreadSanitizer: Bool? = nil,
+        enableUndefinedBehaviorSanitizer: Bool? = nil,
+        enableCodeCoverage: Bool? = nil,
+        testLanguage: String? = nil,
+        testRegion: String? = nil,
+        derivedDataPath: String? = nil,
+        resultBundlePath: String? = nil,
+        allowProvisioningUpdates: Bool = false,
+        allowProvisioningDeviceRegistration: Bool = false,
+        authenticationKeyPath: String? = nil,
+        authenticationKeyID: String? = nil,
+        authenticationKeyIssuerID: String? = nil,
+        skipPackagePluginValidation: Bool = false,
+        skipMacroValidation: Bool = false
+    ) {
+        self.project = project
+        self.workspace = workspace
+        self.scheme = scheme
+        self.destination = destination
+        self.configuraton = configuraton
+        self.arch = arch
+        self.sdk = sdk
+        self.showBuildTimingSummary = showBuildTimingSummary
+        self.enableThreadSanitizer = enableThreadSanitizer
+        self.enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer
+        self.enableCodeCoverage = enableCodeCoverage
+        self.testLanguage = testLanguage
+        self.testRegion = testRegion
+        self.derivedDataPath = derivedDataPath
+        self.resultBundlePath = resultBundlePath
+        self.allowProvisioningUpdates = allowProvisioningUpdates
+        self.allowProvisioningDeviceRegistration = allowProvisioningDeviceRegistration
+        self.authenticationKeyPath = authenticationKeyPath
+        self.authenticationKeyID = authenticationKeyID
+        self.authenticationKeyIssuerID = authenticationKeyIssuerID
+        self.skipPackagePluginValidation = skipPackagePluginValidation
+        self.skipMacroValidation = skipMacroValidation
     }
 
-    if let workspace = workspace {
-      buffer.append(" -workspace \(workspace)")
+    func serializedCommand(action: String) -> String {
+        var buffer = "xcrun xcodebuild"
+
+        if let project = project {
+            buffer.append(" -project \(project)")
+        }
+
+        if let workspace = workspace {
+            buffer.append(" -workspace \(workspace)")
+        }
+
+        if let scheme = scheme {
+            buffer.append(" -scheme \(scheme)")
+        }
+
+        if let destination = destination {
+            buffer.append(" -destination \(destination)")
+        }
+
+        if let arch = arch {
+            for arch in arch {
+                buffer.append(" -arch \(arch)")
+            }
+        }
+
+        if let sdk = sdk {
+            buffer.append(" -sdk \(sdk)")
+        }
+
+        if showBuildTimingSummary {
+            buffer.append(" -showBuildTimingSummary")
+        }
+
+        if let enableThreadSanitizer = enableThreadSanitizer {
+            let value = enableThreadSanitizer ? "YES" : "NO"
+            buffer.append(" -enableThreadSanitizer \(value)")
+        }
+
+        if let enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer {
+            let value = enableUndefinedBehaviorSanitizer ? "YES" : "NO"
+            buffer.append(" -enableUndefinedBehaviorSanitizer \(value)")
+        }
+
+        if let enableCodeCoverage = enableCodeCoverage {
+            let value = enableCodeCoverage ? "YES" : "NO"
+            buffer.append(" -enableCodeCoverage \(value)")
+        }
+
+        if let testLanguage = testLanguage {
+            buffer.append(" -testLanguage \(testLanguage)")
+        }
+
+        if let testRegion = testRegion {
+            buffer.append(" -testRegion \(testRegion)")
+        }
+
+        if let derivedDataPath = derivedDataPath {
+            buffer.append(" -derivedDataPath \(derivedDataPath)")
+        }
+
+        if let resultBundlePath = resultBundlePath {
+            buffer.append(" -resultBundlePath \(resultBundlePath)")
+        }
+
+        if allowProvisioningUpdates {
+            buffer.append(" -allowProvisioningUpdates")
+        }
+
+        if allowProvisioningDeviceRegistration {
+            buffer.append(" -allowProvisioningDeviceRegistration")
+        }
+
+        if let authenticationKeyPath = authenticationKeyPath {
+            buffer.append(" -authenticationKeyPath \(authenticationKeyPath)")
+        }
+
+        if let authenticationKeyID = authenticationKeyID {
+            buffer.append(" -authenticationKeyID \(authenticationKeyID)")
+        }
+
+        if let authenticationKeyIssuerID = authenticationKeyIssuerID {
+            buffer.append(" -authenticationKeyIssuerID \(authenticationKeyIssuerID)")
+        }
+
+        if skipPackagePluginValidation {
+            buffer.append(" -skipPackagePluginValidation")
+        }
+
+        if skipMacroValidation {
+            buffer.append(" -skipMacroValidation")
+        }
+
+        buffer.append(" \(action)")
+
+        return buffer
     }
-
-    if let scheme = scheme {
-      buffer.append(" -scheme \(scheme)")
-    }
-
-    if let destination = destination {
-      buffer.append(" -destination \(destination)")
-    }
-
-    if let arch = arch {
-      for arch in arch {
-        buffer.append(" -arch \(arch)")
-      }
-    }
-
-    if let sdk = sdk {
-      buffer.append(" -sdk \(sdk)")
-    }
-
-    if showBuildTimingSummary {
-      buffer.append(" -showBuildTimingSummary")
-    }
-
-    if let enableThreadSanitizer = enableThreadSanitizer {
-      let value = enableThreadSanitizer ? "YES" : "NO"
-      buffer.append(" -enableThreadSanitizer \(value)")
-    }
-
-    if let enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer {
-      let value = enableUndefinedBehaviorSanitizer ? "YES" : "NO"
-      buffer.append(" -enableUndefinedBehaviorSanitizer \(value)")
-    }
-
-    if let enableCodeCoverage = enableCodeCoverage {
-      let value = enableCodeCoverage ? "YES" : "NO"
-      buffer.append(" -enableCodeCoverage \(value)")
-    }
-
-    if let testLanguage = testLanguage {
-      buffer.append(" -testLanguage \(testLanguage)")
-    }
-
-    if let testRegion = testRegion {
-      buffer.append(" -testRegion \(testRegion)")
-    }
-
-    if let derivedDataPath = derivedDataPath {
-      buffer.append(" -derivedDataPath \(derivedDataPath)")
-    }
-
-    if let resultBundlePath = resultBundlePath {
-      buffer.append(" -resultBundlePath \(resultBundlePath)")
-    }
-
-    if allowProvisioningUpdates {
-      buffer.append(" -allowProvisioningUpdates")
-    }
-
-    if allowProvisioningDeviceRegistration {
-      buffer.append(" -allowProvisioningDeviceRegistration")
-    }
-
-    if let authenticationKeyPath = authenticationKeyPath {
-      buffer.append(" -authenticationKeyPath \(authenticationKeyPath)")
-    }
-
-    if let authenticationKeyID = authenticationKeyID {
-      buffer.append(" -authenticationKeyID \(authenticationKeyID)")
-    }
-
-    if let authenticationKeyIssuerID = authenticationKeyIssuerID {
-      buffer.append(" -authenticationKeyIssuerID \(authenticationKeyIssuerID)")
-    }
-
-    buffer.append(" \(action)")
-
-    return buffer
-  }
 }

--- a/Sources/XCTools/Xcodebuild/Xcodebuild.test.swift
+++ b/Sources/XCTools/Xcodebuild/Xcodebuild.test.swift
@@ -1,7 +1,18 @@
 import Sh
 
 extension Xcodebuild {
-  public func test(_ sink: Sink = .terminal) async throws {
-    try await sh(sink, serializedCommand(action: "test"))
-  }
+    public func test(
+        _ sink: Sink = .terminal,
+        testPlan: String? = nil
+    ) async throws {
+        var action = ""
+
+        if let testPlan {
+            action.append("-testPlan \(testPlan) ")
+        }
+
+        action.append("test")
+
+        try await sh(sink, serializedCommand(action: action))
+    }
 }

--- a/Sources/XCTools/Xcodebuild/Xcodebuild.testWithoutBuilding.swift
+++ b/Sources/XCTools/Xcodebuild/Xcodebuild.testWithoutBuilding.swift
@@ -1,15 +1,27 @@
 import Sh
 
 extension Xcodebuild {
-  /// Test compiled bundles. If a `scheme` is provided then
-  /// the command finds bundles in the build root (SRCROOT).
-  /// If an xctestrun file is provided then the command finds
-  /// bundles at paths specified in the xctestrun file.
-  public func testWithoutBuilding(_ sink: Sink = .terminal, xctestrun: String? = nil) async throws {
-    if let xctestrun = xctestrun {
-      try await sh(sink, serializedCommand(action: "-xctestrun \(xctestrun) test-without-building"))
-    } else {
-      try await sh(sink, serializedCommand(action: "test-without-building"))
+    /// Test compiled bundles. If a `scheme` is provided then
+    /// the command finds bundles in the build root (SRCROOT).
+    /// If an xctestrun file is provided then the command finds
+    /// bundles at paths specified in the xctestrun file.
+    public func testWithoutBuilding(
+        _ sink: Sink = .terminal,
+        testPlan: String? = nil,
+        xctestrun: String? = nil
+    ) async throws {
+        var action = ""
+
+        if let xctestrun {
+            action.append("-xctestrun \(xctestrun) ")
+        }
+
+        if let testPlan {
+            action.append("-testPlan \(testPlan) ")
+        }
+
+        action.append("test-without-building")
+
+        try await sh(sink, serializedCommand(action: action))
     }
-  }
 }


### PR DESCRIPTION
## `xcodebuild`

- Add support for `-verbose`, `-quiet`, `-skipPackagePluginValidation`, and `-skipMacroValidation`
- For the `test` and `test-without-building` actions, add support for `-testPlan`
- For the `--export-archive` action, add support for `-exportPath` and authentication via key path, key ID, and issuer ID.

## `altool`

- Add `--validate-app` action